### PR TITLE
Minor updates

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,3 @@
-
 {
     "env": {
         "browser": true,
@@ -47,6 +46,7 @@
         "no-underscore-dangle": ["error", { "allow": ["_id", "__v", "_gridId"] }],
         "no-plusplus": "error",
         "quotes": "off",
+        "arrow-parens": ["error", "as-needed", { "requireForBlockBody": true }],
         "promise/always-return": "off",
         "promise/no-callback-in-promise": "error",
         "promise/no-nesting": "error",

--- a/README.md
+++ b/README.md
@@ -289,9 +289,6 @@
       OpenVote,
     }
 
-    export default Vote;
-    export { Open }
-
     // import
     import Vote, { OpenVote } from '/path/to/model';
     ```

--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@
 - Sometimes you have to accept what we have and carry on. But don't half ass the shit. Give it a several take before giving up. Leave some comment at least.
 
 # Premise
-- These rules are based on following esline plugins
-  - eslint-config-airbnb
-  - eslint-plugin-import
-  - eslint-plugin-jsx-a11y
-  - eslint-plugin-mocha
-  - eslint-plugin-promise
-  - eslint-plugin-react
+- These rules are based on following eslint plugins
+  - eslint@7.19.0
+  - eslint-config-airbnb@18.2.1
+  - eslint-plugin-import@2.22.1
+  - eslint-plugin-jsx-a11y@6.4.1
+  - eslint-plugin-mocha@8.0.0
+  - eslint-plugin-promise@4.2.1
+  - eslint-plugin-react@7.22.0
 
 # General
 - Don't spam eslint-disable. Try to understand what's the problem is and conform.
@@ -329,6 +330,3 @@
 # References
 - https://github.com/felixge/node-style-guide
 - https://github.com/airbnb/javascript#naming--uppercase
-
-# Notes
-- <a name="no-promise-executor-return">Do not return any value inside Promise</a>: This rule is defined in [eslint](https://eslint.org/docs/rules/no-promise-executor-return), but for some reason I couldn't make it to work. Please make a PR whever was able to fix this.

--- a/src/utils/.eslintrc
+++ b/src/utils/.eslintrc
@@ -2,6 +2,7 @@
     "rules": {
         "no-underscore-dangle": "off",
         "no-await-in-loop": "off",
-        "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }]
+        "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
+        "import/prefer-default-export": "off"
     }
 }


### PR DESCRIPTION
## Proposed Changes
- Fix sample codes
- Allow non-default when it's a single export, only in utils
- Move base eslintrc to root dir

## Notes
- `no-promise-executor-return` rule is supported in 7.3.0 or later. Now, we started to use v7.19.0(Until node-barebone's update, we had used v5.8.0) and it works with new version. So I removed a note about it.
